### PR TITLE
Gulp ruby sass compatability

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -3,7 +3,8 @@
   "version": "0.0.0",
   "homepage": "https://github.com/ericbarnes/gulp-bower-bootstrap-fontawesome",
   "authors": [
-    "Eric Barnes <eric@ericlbarnes.com>"
+    "Eric Barnes <eric@ericlbarnes.com>",
+    "Tommy Derngren <tommy@reseguiden.se>"
   ],
   "license": "MIT",
   "ignore": [
@@ -14,7 +15,7 @@
     "tests"
   ],
   "dependencies": {
-    "bootstrap-sass-official": "~3.3.3",
+    "bootstrap-sass-official": "~3.3.4",
     "fontawesome": "~4.3.0"
   }
 }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -19,18 +19,16 @@ gulp.task('icons', function() {
 });
 
 gulp.task('css', function() {
-    return gulp.src(config.sassPath + '/style.scss')
-        .pipe(sass({
-            style: 'compressed',
-            loadPath: [
-                './resources/sass',
+    return sass('./resources/sass', {
+            style:'compressed',
+            loadPath:[
                 config.bowerDir + '/bootstrap-sass-official/assets/stylesheets',
-                config.bowerDir + '/fontawesome/scss',
+                config.bowerDir + '/fontawesome/scss'
             ]
         })
-            .on("error", notify.onError(function (error) {
-                return "Error: " + error.message;
-            })))
+        .on("error", notify.onError(function (error) {
+            return "Error: " + error.message;
+        }))
         .pipe(gulp.dest('./public/css'));
 });
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,42 +1,42 @@
-var gulp = require('gulp'), 
-    sass = require('gulp-ruby-sass') 
-    notify = require("gulp-notify") 
-    bower = require('gulp-bower');
+var gulp = require('gulp');
+var sass = require('gulp-ruby-sass');
+var notify = require("gulp-notify");
+var bower = require('gulp-bower');
 
 var config = {
-     sassPath: './resources/sass',
-     bowerDir: './bower_components' 
-}
+    sassPath: './resources/sass',
+    bowerDir: './bower_components'
+};
 
-gulp.task('bower', function() { 
+gulp.task('bower', function() {
     return bower()
-         .pipe(gulp.dest(config.bowerDir)) 
+        .pipe(gulp.dest(config.bowerDir));
 });
 
-gulp.task('icons', function() { 
-    return gulp.src(config.bowerDir + '/fontawesome/fonts/**.*') 
-        .pipe(gulp.dest('./public/fonts')); 
+gulp.task('icons', function() {
+    return gulp.src(config.bowerDir + '/fontawesome/fonts/**.*')
+        .pipe(gulp.dest('./public/fonts'));
 });
 
-gulp.task('css', function() { 
+gulp.task('css', function() {
     return gulp.src(config.sassPath + '/style.scss')
-         .pipe(sass({
-             style: 'compressed',
-             loadPath: [
-                 './resources/sass',
-                 config.bowerDir + '/bootstrap-sass-official/assets/stylesheets',
-                 config.bowerDir + '/fontawesome/scss',
-             ]
-         }) 
+        .pipe(sass({
+            style: 'compressed',
+            loadPath: [
+                './resources/sass',
+                config.bowerDir + '/bootstrap-sass-official/assets/stylesheets',
+                config.bowerDir + '/fontawesome/scss',
+            ]
+        })
             .on("error", notify.onError(function (error) {
-                 return "Error: " + error.message;
-             }))) 
-         .pipe(gulp.dest('./public/css')); 
+                return "Error: " + error.message;
+            })))
+        .pipe(gulp.dest('./public/css'));
 });
 
 // Rerun the task when a file changes
- gulp.task('watch', function() {
-     gulp.watch(config.sassPath + '/**/*.scss', ['css']); 
+gulp.task('watch', function() {
+    gulp.watch(config.sassPath + '/**/*.scss', ['css']);
 });
 
-  gulp.task('default', ['bower', 'icons', 'css']);
+gulp.task('default', ['bower', 'icons', 'css']);

--- a/package.json
+++ b/package.json
@@ -3,6 +3,6 @@
     "gulp": "^3.8.11",
     "gulp-bower": "0.0.10",
     "gulp-notify": "^2.2.0",
-    "gulp-ruby-sass": "^0.7.1"
+    "gulp-ruby-sass": "^1.0.5"
   }
 }


### PR DESCRIPTION
With this patch the tutorial works with later versions gulp-ruby-sass. I also fixed some jshint errors in the gulpfile.
