### PR TITLE
Added watch task to default task

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -39,4 +39,4 @@ gulp.task('css', function() { 
      gulp.watch(config.sassPath + '/**/*.scss', ['css']); 
 });
 
-  gulp.task('default', ['bower', 'icons', 'css']);
+  gulp.task('default', ['watch', 'bower', 'icons', 'css']);


### PR DESCRIPTION
Automated builds were not occuring after modifications to .scss files. After looking at the code I have come to find that the watch task is never actually started, I have added the watch task to the default task to get automatic builds working...

Looks like my commit history is includes an erroneous pull request on my own fork. Let me know if you want me to clean that up if it's of a big concern.
